### PR TITLE
fix: ECS args

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = False
 tag = True
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+clean: clean-build clean-pyc clean-test
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test:
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+
+lint: lint/flake8 lint/black
+
+lint/flake8:
+	flake8 src tests
+
+lint/black:
+	black --check src tests
+
+test: test/mypy test/pytest
+
+test/pytest:
+	pytest
+
+test/mypy:
+	mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = """
     """
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     {name = "Dylan Halpern", email = "dhalpern@uchicago.edu"},
     {name = "Nicholas Marchio", email = "nmarchio@uchicago.edu"},

--- a/src/cloudtile/cli/__init__.py
+++ b/src/cloudtile/cli/__init__.py
@@ -156,5 +156,6 @@ class CloudTileCLI:
             elif not isinstance(argval, bool) and argval is not None:
                 args.append(str(argval))
         args.append("--s3")
-        args.append(" ".join(tc_settings))
+        if len(tc_settings) > 1:
+            args.append(" ".join(tc_settings))
         return args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,6 +241,32 @@ class TestConvertSubcommand:
                 "--tc-kwargs visalingam maximum-zoom=g",
             ],
         ],
+        [
+            [
+                "convert",
+                "single-step",
+                "test.parquet",
+                "4",
+                "5",
+                "--ecs",
+                "--memory=1024",
+                "--suffix=test",
+            ],
+            [
+                "convert",
+                "single-step",
+                "test.parquet",
+                "4",
+                "5",
+                "--suffix",
+                "test",
+                "--s3",
+            ],
+        ],
+        [
+            ["convert", "single-step", "test.parquet", "4", "5"],
+            ["convert", "single-step", "test.parquet", "4", "5", "--s3"],
+        ],
     ),
 )
 def test_get_args_for_ecs(args: list[str], expected: list[str]) -> None:


### PR DESCRIPTION
# Description

Introducing the `--tc-kwargs` functionality from #34 had a bug when no settings were passed. This mean that even though the CLI was working locally, when it came to sending the CLI args to the ECS container was wrong. This PR fixes that issue and extends unit tests to check for this case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Extended unit tests within `tests/test_ecs.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made sure to bump the version within `pyproject.toml` respectively
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes